### PR TITLE
[fix] skip fqcn

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,3 +8,5 @@ exclude_paths:
   - ./roles/ghq_github/
   - ./roles/vscode_extentions/
   - lefthook.yml
+skip_list:
+  - 'fqcn'


### PR DESCRIPTION
WARNING  Listing 2 violation(s) that are fatal
roles/homebrew/tasks/main.yml:2: fqcn[action] (warning)
roles/homebrew_cask/tasks/main.yml:2: fqcn[action] (warning)